### PR TITLE
Split nuget release from build workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       BUILD_CONFIG: 'Release'
-      SOLUTION: 'EmbeddedResourceProperty.sln'
+      SOLUTION: '*.sln'
 
     runs-on: ubuntu-latest
 
@@ -44,56 +44,32 @@ jobs:
     - name: Run tests
       run: dotnet test --configuration $BUILD_CONFIG --no-restore --no-build --verbosity normal
 
+    - name: Pack NuGet packages
+      run: |
+        dotnet pack $SOLUTION --configuration $BUILD_CONFIG --no-build --output ./artifacts
+        echo "=== Packages created ==="
+        ls -la ./artifacts/
+
     - name: Get tag for current commit
       id: get_tag
+      # Check for tags when triggered by main branch push (with tag) or direct tag push
+      # Can't use github.ref_name because it's "main" when pushing branch+tag together
       if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
-      run: |
-        TAG=$(git tag --points-at HEAD | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 1)
-        echo "tag=$TAG" >> $GITHUB_OUTPUT
-        echo "Found tag: $TAG"
-
-    - name: Pack NuGet package
-      if: steps.get_tag.outputs.tag != ''
-      run: dotnet pack src/EmbeddedResourcePropertyGenerator/EmbeddedResourcePropertyGenerator.csproj --configuration $BUILD_CONFIG --no-build --output ./artifacts
-      
-    - name: Publish to NuGet
-      if: steps.get_tag.outputs.tag != ''
-      run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      uses: olegtarasov/get-tag@v2.1.4
       
     - name: Extract release notes from CHANGELOG.md
       if: steps.get_tag.outputs.tag != ''
       id: extract_notes
-      run: |
-        VERSION="${{ steps.get_tag.outputs.tag }}"
-        echo "Extracting notes for version: $VERSION"
-
-        NOTES=$(awk -v ver="v$VERSION" '
-          $0 ~ "^## "ver"$" {flag=1; next}
-          flag && $0 ~ "^## " {flag=0}
-          flag
-        ' <(sed "s/\r$//" CHANGELOG.md) | awk '!/^Release Date:/')
-        NOTES=$(echo "$NOTES" | sed '/./,$!d' | tac | sed '/./,$!d' | tac)
-
-        if [ -z "$NOTES" ]; then
-          echo "Did not find notes with 'v' prefix, trying without."
-          NOTES=$(awk -v ver="$VERSION" '
-            $0 ~ "^## "ver"$" {flag=1; next}
-            flag && $0 ~ "^## " {flag=0}
-            flag
-          ' <(sed "s/\r$//" CHANGELOG.md) | awk '!/^Release Date:/')
-          NOTES=$(echo "$NOTES" | sed '/./,$!d' | tac | sed '/./,$!d' | tac)
-        fi
-
-        # Set output
-        echo "notes<<EOF" >> $GITHUB_OUTPUT
-        echo "$NOTES" >> $GITHUB_OUTPUT
-        echo "EOF" >> $GITHUB_OUTPUT
+      uses: mindsers/changelog-reader-action@v2
+      with:
+        version: ${{ steps.get_tag.outputs.tag }}
+        path: ./CHANGELOG.md
 
     - name: Create GitHub Release
       if: steps.get_tag.outputs.tag != ''
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ steps.get_tag.outputs.tag }}
-        body: ${{ steps.extract_notes.outputs.notes }}
+        body: ${{ steps.extract_notes.outputs.changes }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish to NuGet
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Restore, Build, and Pack
+      run: |
+        dotnet restore *.sln
+        dotnet build *.sln --configuration Release --no-restore
+        dotnet pack *.sln --configuration Release --no-build --output ./artifacts
+
+    - name: Publish to NuGet
+      run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,76 +1,83 @@
-Changelog
---- 
+# Changelog
 
-## v1.1.0
-Release Date: 2025-06-29
+All notable changes to this project will be documented in this file.
 
-### Features
-- Rewrote the generator pipeline to improve performance, and only regenerate when additional texts are changed (resolves #4)
-- Added support for nested classes and generics (resolves #3)
-- Made integration easier by automatically including EmbeddedResources as Additional Text Files
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [[1.1.0]] - 2025-06-29
+
+### Added
+- Support for nested classes and generics
+- Automatic inclusion of EmbeddedResources as Additional Text Files to make integration easier
+
+### Changed
+- Rewrote the generator pipeline to improve performance and only regenerate when additional texts are changed
 - Lowered the minimum version of Microsoft.CodeAnalysis.CSharp required to support older .NET versions
 
-**Full Changelog**: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/1.0.0...1.1.0
+### Fixed
+- Resolves issue #4 (performance improvements)
+- Resolves issue #3 (nested classes and generics support)
 
-## v1.0.0
-Release Date: 2024-10-28
+## [[1.0.0]] - 2024-10-28
 
-### Features
+### Added
+- First stable release
 
-* First stable release
+## [[0.0.1-alpha.6b]] - 2024-09-24
 
-## v0.0.1-alpha.6b
-Release Date: 2024-09-24
+### Fixed
+- Corrected the published package (but the new version broke the doc links)
 
-### Fixes
-* Corrected the published package (but the new version broke the doc links)
+## [[0.0.1-alpha.6]] - 2024-09-24
 
-## v0.0.1-alpha.6
-Release Date: 2024-09-24
+### Added
+- More documentation
 
-### Features
+### Changed
+- Removed windows specific paths from tests
 
-* Removed windows specific paths from tests
-* More documentation
+## [[0.0.1-alpha.5]] - 2024-09-22
 
-## v0.0.1-alpha.5
-Release Date: 2024-09-22
+### Fixed
+- Included doc-comments of the EmbeddedResourceProperties attribute in the package
 
-### Fixes
+## [[0.0.1-alpha.4]] - 2024-09-15
 
-* Included doc-comments of the EmbeddedResourceProperties attribute in the package
+### Added
+- Read method in each class
+- The Read method, backing fields, and resource names are now available to the class
 
-## v0.0.1-alpha.4
-Release Date: 2024-09-15
+### Changed
+- Moved the attribute to its own dll
 
-### Features
+## [[0.0.1-alpha.3]] - 2024-09-14
 
-* Moved the attribute to its own dll
-* Include Read method in each class
-* The Read method, backing fields, and resource names are available to the class
+### Added
+- Included `EmbeddedResourcePropertyExample` project in github repository
 
-## v0.0.1-alpha.3
-Release Date: 2024-09-14
+### Fixed
+- Removing doc duplication
 
-### Features
+## [[0.0.1-alpha.2]] - 2024-09-13
 
-* Included `EmbeddedResourcePropertyExample` project in github repository
+### Added
+- `[Conditional]` attribute to restrict inclusion of the usage of the `EmbeddedResourcePropertiesAttribute` in the output
 
-### Fixes
+## [[0.0.1-alpha]] - 2024-09-09
 
-* Removing doc duplication
+### Added
+- Support for overriding `ReadEmbeddedResourceValue` partial method
 
-## v0.0.1-alpha.2
-Release Date: 2024-09-13
-
-### Features
-
-* Add `[Conditional]` attribute to restrict inclusion of the usage of 
-  the `EmbeddedResourcePropertiesAttribute` in the output.
-
-## v0.0.1-alpha
-Release Date: 2024-09-09
-
-### Features
-
-* Add support for overriding `ReadEmbeddedResourceValue` partial method
+[Unreleased]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/1.0.0...1.1.0
+[1.0.0]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.6b...1.0.0
+[0.0.1-alpha.6b]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.6...0.0.1-alpha.6b
+[0.0.1-alpha.6]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.5...0.0.1-alpha.6
+[0.0.1-alpha.5]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.4...0.0.1-alpha.5
+[0.0.1-alpha.4]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.3...0.0.1-alpha.4
+[0.0.1-alpha.3]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha.2...0.0.1-alpha.3
+[0.0.1-alpha.2]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/compare/0.0.1-alpha...0.0.1-alpha.2
+[0.0.1-alpha]: https://github.com/datacute/EmbeddedResourcePropertyGenerator/releases/tag/0.0.1-alpha

--- a/EmbeddedResourcePropertyExample/EmbeddedResourcePropertyExample.csproj
+++ b/EmbeddedResourcePropertyExample/EmbeddedResourcePropertyExample.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/EmbeddedResourcePropertyGenerator.Attributes/EmbeddedResourcePropertyGenerator.Attributes.csproj
+++ b/EmbeddedResourcePropertyGenerator.Attributes/EmbeddedResourcePropertyGenerator.Attributes.csproj
@@ -11,6 +11,7 @@
 
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
 </Project>

--- a/EmbeddedResourcePropertyGenerator.Tests/EmbeddedResourcePropertyGenerator.Tests.csproj
+++ b/EmbeddedResourcePropertyGenerator.Tests/EmbeddedResourcePropertyGenerator.Tests.csproj
@@ -5,8 +5,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
-
-        <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>
 


### PR DESCRIPTION
Split nuget release from build workflow.
Use 3rd party actions.
Use "Keep a Changelog" format.